### PR TITLE
[StreamsCharts] Add support for obtaining exact timestamps (#3)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,7 @@ pub struct Cli {
 
     /// Explicitly use bruteforce mode for StreamsCharts 
     #[clap(short, long)]
-    pub brutefoce: Option<bool>,
+    pub bruteforce: Option<bool>,
 }
 
 #[derive(Subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ pub struct Flags {
     pub simple: bool,
     pub pbar: bool,
     pub cdnfile: Option<String>,
+    pub bruteforce: Option<bool>,
 }
 
 impl Default for Flags {
@@ -17,6 +18,7 @@ impl Default for Flags {
             simple: false,
             pbar: false,
             cdnfile: None,
+            bruteforce: None,
         }
     }
 }
@@ -38,6 +40,10 @@ pub struct Cli {
 
     #[clap(subcommand)]
     pub command: Option<Commands>,
+
+    /// Explicitly use bruteforce mode for StreamsCharts 
+    #[clap(short, long)]
+    pub brutefoce: Option<bool>,
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ fn interface(matches: Cli) {
             stdin().read_line(&mut url).expect("Failed to read line.");
             trim_newline(&mut url);
 
-            let (proc, data) = match derive_date_from_url(&url) {
+            let (proc, data) = match derive_date_from_url(&url, None) {
                 Ok(a) => a,
                 Err(e) => {
                     error!("{}", e);
@@ -230,6 +230,37 @@ fn interface(matches: Cli) {
                             }
                         },
                         data.start_date.as_str(),
+                        fl.clone(),
+                    ) {
+                        Ok(u) => match u {
+                            Some(u) => u,
+                            None => Vec::new(),
+                        },
+                        Err(e) => {
+                            error!("{}", e);
+                            return;
+                        }
+                    }
+                }
+                ProcessingType::Bruteforce => {
+                    let end_date = match data.end_date {
+                        Some(d) => d,
+                        None => {
+                            error!("Couldn't get the end date for the bruteforce method");
+                            return;
+                        }
+                    };
+                    match bruteforcer(
+                        data.username.as_str(),
+                        match data.broadcast_id.parse::<i64>() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                error!("{}", e);
+                                return;
+                            }
+                        },
+                        data.start_date.as_str(),
+                        end_date.as_str(),
                         fl.clone(),
                     ) {
                         Ok(u) => match u {
@@ -337,7 +368,7 @@ fn interface(matches: Cli) {
                 Ok(r) => match r {
                     Some((username, vod)) => {
                         let url = format!("https://twitchtracker.com/{}/streams/{}", username, vod);
-                        let (_, data) = match derive_date_from_url(&url) {
+                        let (_, data) = match derive_date_from_url(&url, None) {
                             Ok(a) => a,
                             Err(e) => {
                                 error!("{}", e);
@@ -588,7 +619,7 @@ fn main() {
         }
         Some(Commands::Link { progressbar, url }) => {
             let url = url.as_str();
-            let (proc, data) = match derive_date_from_url(&url) {
+            let (proc, data) = match derive_date_from_url(&url, None) {
                 Ok(a) => a,
                 Err(e) => {
                     error!("{}", e);
@@ -627,6 +658,37 @@ fn main() {
                         }
                     }
                 }
+                ProcessingType::Bruteforce => {
+                    let end_date = match data.end_date {
+                        Some(d) => d,
+                        None => {
+                            error!("Couldn't get the end date for the bruteforce method");
+                            return;
+                        }
+                    };
+                    match bruteforcer(
+                        data.username.as_str(),
+                        match data.broadcast_id.parse::<i64>() {
+                            Ok(b) => b,
+                            Err(e) => {
+                                error!("{}", e);
+                                return;
+                            }
+                        },
+                        data.start_date.as_str(),
+                        end_date.as_str(),
+                        fl.clone(),
+                    ) {
+                        Ok(u) => match u {
+                            Some(u) => u,
+                            None => Vec::new(),
+                        },
+                        Err(e) => {
+                            error!("{}", e);
+                            return;
+                        }
+                    }
+                }
             };
         }
         Some(Commands::Clip { progressbar, clip }) => {
@@ -641,7 +703,7 @@ fn main() {
                 Ok(r) => match r {
                     Some((username, vod)) => {
                         let url = format!("https://twitchtracker.com/{}/streams/{}", username, vod);
-                        let (_, data) = match derive_date_from_url(&url) {
+                        let (_, data) = match derive_date_from_url(&url, None) {
                             Ok(a) => a,
                             Err(e) => {
                                 error!("{}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,37 +242,6 @@ fn interface(matches: Cli) {
                         }
                     }
                 }
-                ProcessingType::Bruteforce => {
-                    let end_date = match data.end_date {
-                        Some(d) => d,
-                        None => {
-                            error!("Couldn't get the end date for the bruteforce method");
-                            return;
-                        }
-                    };
-                    match bruteforcer(
-                        data.username.as_str(),
-                        match data.broadcast_id.parse::<i64>() {
-                            Ok(b) => b,
-                            Err(e) => {
-                                error!("{}", e);
-                                return;
-                            }
-                        },
-                        data.start_date.as_str(),
-                        end_date.as_str(),
-                        fl.clone(),
-                    ) {
-                        Ok(u) => match u {
-                            Some(u) => u,
-                            None => Vec::new(),
-                        },
-                        Err(e) => {
-                            error!("{}", e);
-                            return;
-                        }
-                    }
-                }
             };
             if !valid_urls.is_empty() {
                 if valid_urls[0].muted {
@@ -646,37 +615,6 @@ fn main() {
                             }
                         },
                         data.start_date.as_str(),
-                        fl.clone(),
-                    ) {
-                        Ok(u) => match u {
-                            Some(u) => u,
-                            None => Vec::new(),
-                        },
-                        Err(e) => {
-                            error!("{}", e);
-                            return;
-                        }
-                    }
-                }
-                ProcessingType::Bruteforce => {
-                    let end_date = match data.end_date {
-                        Some(d) => d,
-                        None => {
-                            error!("Couldn't get the end date for the bruteforce method");
-                            return;
-                        }
-                    };
-                    match bruteforcer(
-                        data.username.as_str(),
-                        match data.broadcast_id.parse::<i64>() {
-                            Ok(b) => b,
-                            Err(e) => {
-                                error!("{}", e);
-                                return;
-                            }
-                        },
-                        data.start_date.as_str(),
-                        end_date.as_str(),
                         fl.clone(),
                     ) {
                         Ok(u) => match u {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ fn interface(matches: Cli) {
                 simple: false,
                 pbar: true,
                 cdnfile: matches.cdnfile,
+                bruteforce: None,
             };
 
             let valid_urls = match exact(
@@ -147,6 +148,7 @@ fn interface(matches: Cli) {
                 simple: false,
                 pbar: true,
                 cdnfile: matches.cdnfile,
+                bruteforce: None,
             };
 
             let valid_urls = match bruteforcer(
@@ -203,19 +205,20 @@ fn interface(matches: Cli) {
             stdin().read_line(&mut url).expect("Failed to read line.");
             trim_newline(&mut url);
 
-            let (proc, data) = match derive_date_from_url(&url, None) {
-                Ok(a) => a,
-                Err(e) => {
-                    error!("{}", e);
-                    return;
-                }
-            };
-
             let fl = Flags {
                 verbose: false,
                 simple: false,
                 pbar: true,
                 cdnfile: matches.cdnfile,
+                bruteforce: matches.brutefoce,
+            };
+
+            let (proc, data) = match derive_date_from_url(&url, fl.clone()) {
+                Ok(a) => a,
+                Err(e) => {
+                    error!("{}", e);
+                    return;
+                }
             };
 
             let valid_urls = match proc {
@@ -313,6 +316,7 @@ fn interface(matches: Cli) {
                 simple: false,
                 pbar: true,
                 cdnfile: matches.cdnfile,
+                bruteforce: None,
             };
 
             let valid_urls = match live(username.as_str(), fl.clone()) {
@@ -362,13 +366,14 @@ fn interface(matches: Cli) {
                 simple: false,
                 pbar: true,
                 cdnfile: matches.cdnfile,
+                bruteforce: None,
             };
 
             match find_bid_from_clip(clip, fl.clone()) {
                 Ok(r) => match r {
                     Some((username, vod)) => {
                         let url = format!("https://twitchtracker.com/{}/streams/{}", username, vod);
-                        let (_, data) = match derive_date_from_url(&url, None) {
+                        let (_, data) = match derive_date_from_url(&url, fl.clone()) {
                             Ok(a) => a,
                             Err(e) => {
                                 error!("{}", e);
@@ -473,6 +478,7 @@ fn interface(matches: Cli) {
                     simple: false,
                     pbar: true,
                     cdnfile: matches.cdnfile,
+                    bruteforce: None,
                 },
             );
 
@@ -490,6 +496,7 @@ fn interface(matches: Cli) {
                 simple: false,
                 pbar: true,
                 cdnfile: matches.cdnfile,
+                bruteforce: None,
             };
 
             match fix(url.as_str(), None, false, fl) {
@@ -558,6 +565,7 @@ fn main() {
                 simple: matches.simple,
                 pbar: progressbar,
                 cdnfile: matches.cdnfile,
+                bruteforce: matches.brutefoce,
             };
 
             match bruteforcer(username, id, initial_from_stamp, initial_to_stamp, flags) {
@@ -586,6 +594,7 @@ fn main() {
                     simple: matches.simple,
                     pbar: progressbar,
                     cdnfile: matches.cdnfile,
+                    bruteforce: matches.brutefoce,
                 },
             ) {
                 Ok(_) => {}
@@ -608,6 +617,7 @@ fn main() {
                     simple: matches.simple,
                     pbar: progressbar,
                     cdnfile: matches.cdnfile,
+                    bruteforce: matches.brutefoce,
                 },
             ) {
                 Ok(_) => {}
@@ -618,20 +628,21 @@ fn main() {
             };
         }
         Some(Commands::Link { progressbar, url }) => {
-            let url = url.as_str();
-            let (proc, data) = match derive_date_from_url(&url, None) {
-                Ok(a) => a,
-                Err(e) => {
-                    error!("{}", e);
-                    return;
-                }
-            };
-
             let fl = Flags {
                 verbose: matches.verbose,
                 simple: matches.simple,
                 pbar: progressbar,
                 cdnfile: matches.cdnfile,
+                bruteforce: matches.brutefoce,
+            };
+
+            let url = url.as_str();
+            let (proc, data) = match derive_date_from_url(&url, fl.clone()) {
+                Ok(a) => a,
+                Err(e) => {
+                    error!("{}", e);
+                    return;
+                }
             };
 
             match proc {
@@ -697,13 +708,14 @@ fn main() {
                 simple: matches.simple,
                 pbar: progressbar,
                 cdnfile: matches.cdnfile,
+                bruteforce: matches.brutefoce,
             };
 
             match find_bid_from_clip(clip, fl.clone()) {
                 Ok(r) => match r {
                     Some((username, vod)) => {
                         let url = format!("https://twitchtracker.com/{}/streams/{}", username, vod);
-                        let (_, data) = match derive_date_from_url(&url, None) {
+                        let (_, data) = match derive_date_from_url(&url, fl.clone()) {
                             Ok(a) => a,
                             Err(e) => {
                                 error!("{}", e);
@@ -742,6 +754,7 @@ fn main() {
                     simple: matches.simple,
                     pbar: progressbar,
                     cdnfile: matches.cdnfile,
+                    bruteforce: matches.brutefoce,
                 },
             );
         }
@@ -759,6 +772,7 @@ fn main() {
                 simple: matches.simple,
                 pbar: progressbar,
                 cdnfile: matches.cdnfile,
+                bruteforce: matches.brutefoce,
             },
         ) {
             Ok(_) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,7 @@ fn interface(matches: Cli) {
                 simple: false,
                 pbar: true,
                 cdnfile: matches.cdnfile,
-                bruteforce: matches.brutefoce,
+                bruteforce: matches.bruteforce,
             };
 
             let (proc, data) = match derive_date_from_url(&url, fl.clone()) {
@@ -565,7 +565,7 @@ fn main() {
                 simple: matches.simple,
                 pbar: progressbar,
                 cdnfile: matches.cdnfile,
-                bruteforce: matches.brutefoce,
+                bruteforce: matches.bruteforce,
             };
 
             match bruteforcer(username, id, initial_from_stamp, initial_to_stamp, flags) {
@@ -594,7 +594,7 @@ fn main() {
                     simple: matches.simple,
                     pbar: progressbar,
                     cdnfile: matches.cdnfile,
-                    bruteforce: matches.brutefoce,
+                    bruteforce: matches.bruteforce,
                 },
             ) {
                 Ok(_) => {}
@@ -617,7 +617,7 @@ fn main() {
                     simple: matches.simple,
                     pbar: progressbar,
                     cdnfile: matches.cdnfile,
-                    bruteforce: matches.brutefoce,
+                    bruteforce: matches.bruteforce,
                 },
             ) {
                 Ok(_) => {}
@@ -633,7 +633,7 @@ fn main() {
                 simple: matches.simple,
                 pbar: progressbar,
                 cdnfile: matches.cdnfile,
-                bruteforce: matches.brutefoce,
+                bruteforce: matches.bruteforce,
             };
 
             let url = url.as_str();
@@ -708,7 +708,7 @@ fn main() {
                 simple: matches.simple,
                 pbar: progressbar,
                 cdnfile: matches.cdnfile,
-                bruteforce: matches.brutefoce,
+                bruteforce: matches.bruteforce,
             };
 
             match find_bid_from_clip(clip, fl.clone()) {
@@ -754,7 +754,7 @@ fn main() {
                     simple: matches.simple,
                     pbar: progressbar,
                     cdnfile: matches.cdnfile,
-                    bruteforce: matches.brutefoce,
+                    bruteforce: matches.bruteforce,
                 },
             );
         }
@@ -772,7 +772,7 @@ fn main() {
                 simple: matches.simple,
                 pbar: progressbar,
                 cdnfile: matches.cdnfile,
-                bruteforce: matches.brutefoce,
+                bruteforce: matches.bruteforce,
             },
         ) {
             Ok(_) => {}

--- a/src/util.rs
+++ b/src/util.rs
@@ -213,7 +213,7 @@ pub fn derive_date_from_url(url: &str, flags: Flags) -> Result<(ProcessingType, 
                                 Ok(f) => f,
                                 Err(e) => Err(e)?,
                             };
-                            info!("Value: {}", flags.simple);
+
                             let extracted_results: ExtractedTimestamps = match flags.bruteforce {
                                 Some(true) => {
                                     if !flags.simple {
@@ -689,7 +689,7 @@ mod tests {
                     end_date: Some("1662540600".to_string())
                 }
             ),
-            "testing streamscharts (exact with brutefoce fallback) - https://streamscharts.com/channels/robcdee/streams/39648192487"
+            "testing streamscharts (exact with bruteforce fallback) - https://streamscharts.com/channels/robcdee/streams/39648192487"
         );
 
         assert_eq!(


### PR DESCRIPTION
You can obtain the exact start and end timestamps of a given stream from StreamsCharts within a div on the page. As a result, users no longer have to bruteforce for a URL.

- Adds support for obtaining exact start/end stream timestamps for StreamsCharts
- Removed `ProcessingType::Bruteforce` and refactored code respectively
- Updated the existing test for StreamsCharts to reflect the changes

Some things to consider are the potential for this to change if they ever were to remove the data from their page as discussed in #3. Perhaps in the future having support for either bruteforcing or exact would be beneficial. Additionally, it would probably be better to include both methods, but instead provide `ProcessingType::Bruteforce` as a fallback should the exact timestamp data not be found on the page. I am open to suggestions.