### PR TITLE
Add an update subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +537,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "guess_host_triple"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35a8ce923c7490629d84e12fa2f75e1733f1ec692a47c264f9b7fd632855afc"
+dependencies = [
+ "errno",
+ "libc",
+ "log",
+ "winapi",
 ]
 
 [[package]]
@@ -1628,6 +1661,7 @@ dependencies = [
  "colored",
  "crossterm",
  "env_logger",
+ "guess_host_triple",
  "indicatif",
  "lazy_static",
  "log",
@@ -1637,6 +1671,7 @@ dependencies = [
  "regex",
  "reqwest",
  "scraper",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ alphanumeric-sort = "1.4.0"
 rand = "0.8"
 anyhow = "1.0"
 strum = { version = "0.24", features = ["derive"] }
+semver = "1.0"
+guess_host_triple = "0.1"
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,9 +124,19 @@ pub enum Commands {
         #[clap(short, long)]
         slow: bool,
     },
+
+    /// Check for updates
+    Update,
 }
 
 impl Commands {
+    pub fn show_description(&self) -> bool {
+        match self {
+            Self::Update => false,
+            _ => true,
+        }
+    }
+
     pub fn to_short_desc(&self) -> String {
         match self {
             Self::Exact { .. } => "Exact mode".to_string(),
@@ -136,21 +146,37 @@ impl Commands {
             Self::Clip { .. } => "Clip mode".to_string(),
             Self::Clipforce { .. } => "Clip bruteforce mode".to_string(),
             Self::Fix { .. } => "Fix playlist".to_string(),
+            Self::Update => "Check for updates".to_string(),
         }
     }
 
-    pub fn from_selector(s: usize) -> Option<Self> {
-        if s > 0 {
-            let s = s - 1;
-            match Self::VARIANTS.get(s) {
-                Some(a) => match Self::from_str(a) {
-                    Ok(e) => Some(e),
-                    Err(_) => None,
-                },
-                None => None,
+    pub fn to_selector(&self) -> Option<String> {
+        match self {
+            Self::Update => Some("u".to_string()),
+            _ => None,
+        }
+    }
+
+    pub fn from_selector(s: String) -> Option<Self> {
+        match s.parse::<usize>() {
+            Ok(s) => {
+                if s > 0 {
+                    let s = s - 1;
+                    match Self::VARIANTS.get(s) {
+                        Some(a) => match Self::from_str(a) {
+                            Ok(e) => Some(e),
+                            Err(_) => None,
+                        },
+                        None => None,
+                    }
+                } else {
+                    None
+                }
             }
-        } else {
-            None
+            Err(_) => match s.as_str() {
+                "u" => Some(Self::Update),
+                _ => None,
+            },
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 mod error;
 mod interface;
 mod twitch;
+mod update;
 mod util;
 
 use clap::{crate_name, crate_version, Parser};
@@ -53,17 +54,10 @@ fn main() {
     }));
 
     match matches.command {
-        Some(sub) => {
-            let matches = Cli {
-                command: None,
-                ..matches
-            };
-
-            match sub.execute(matches) {
-                Ok(_) => {}
-                Err(e) => error!("{}", e),
-            }
-        }
+        Some(ref sub) => match sub.execute(matches.clone()) {
+            Ok(_) => {}
+            Err(e) => error!("{}", e),
+        },
         None => main_interface(matches),
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,74 @@
+use anyhow::Result;
+use clap::crate_version;
+use serde::Deserialize;
+use semver::Version;
+use reqwest::header::USER_AGENT;
+use guess_host_triple::guess_host_triple;
+
+use crate::config::{Cli, CURL_UA};
+
+#[derive(Debug, Deserialize)]
+struct GithubUpdate {
+	tag_name: String,
+	assets: Vec<GithubAssets>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubAssets {
+	browser_download_url: String,
+}
+
+pub fn update(matches: Cli) -> Result<()> {
+	let target_triple = guess_host_triple();
+    let current_version = crate_version!();
+	let cur_version_parsed = Version::parse(current_version).unwrap();
+
+    let resp = crate::HTTP_CLIENT
+		.get("https://api.github.com/repos/vyneer/tbf/releases/latest")
+		.header(USER_AGENT, CURL_UA)
+		.send();
+
+	let mut gh = match resp {
+		Ok(r) => {
+			match r.status().is_success() {
+				true => {
+					let gh: GithubUpdate = match r.json() {
+						Ok(v) => v,
+						Err(e) => return Err(e)?,
+					};
+
+					gh
+				}
+				false => GithubUpdate { tag_name: "".to_string(), assets: vec![] }
+			}
+		},
+		Err(e) => return Err(e)?
+	};
+
+	if gh.tag_name != "" && !gh.assets.is_empty() {
+		gh.tag_name.remove(0);
+		let new_version_parsed = Version::parse(&gh.tag_name).unwrap();
+
+		if new_version_parsed > cur_version_parsed {
+			if !matches.simple {
+				println!("New version available ({}):", gh.tag_name);
+			}
+			for url in gh.assets {
+				match target_triple {
+					Some(triple) => {
+						if url.browser_download_url.contains(triple) {
+							println!("{}", url.browser_download_url)
+						}
+					}
+					None => println!("{}", url.browser_download_url)
+				}
+			}
+		} else {
+			if !matches.simple {
+				println!("No updates available");
+			}
+		}
+	}
+
+    Ok(())
+}


### PR DESCRIPTION
- Added an ```update``` subcommand, which checks if there's a new release available and outputs an platform-appropriate link (if one exists)

Originally I tried using the ```self_update``` [crate](https://crates.io/crates/self_update) which had the option to automatically replace the existing binary, but it seemed to mess with the ```reqwest``` crate for whatever reason (more specifically, I started getting random 403s for StreamsCharts). That prompted me to add the next point on the list...

- Added an optional StreamsCharts user agent test (can launch it with ```cargo test -- --ignored```

The reason it's optional is because it's way too slow to keep in the regular rotation, and making it faster is likely impossible since you get throttled by StreamsCharts (429s)